### PR TITLE
Fix: Trimming subheading text on "How to: Not Sure if it is An Issue" page

### DIFF
--- a/public/content/documentation/how-to-test/type/not-sure-if-it-is-an-issue.md
+++ b/public/content/documentation/how-to-test/type/not-sure-if-it-is-an-issue.md
@@ -1,6 +1,6 @@
 ## General Notes
 
-When conducting accessibility testing, testers may come across barriers that could be accessibility-related issues, or they could be unrelated. If you're unsure whether the problem you've identified is a genuine accessibility issue, the following steps can help you verify it.
+While testing for accessibility you may encounter barriers which could be related or unrelated to accessibility. If unsure, the following steps can help verify it.
 
 ## Developer Notes
 

--- a/src/shared/content.json
+++ b/src/shared/content.json
@@ -1329,7 +1329,7 @@
           "label": "Not Sure If It Is An Issue",
           "name": "not-sure-if-it-is-an-issue",
           "type": "file",
-          "generalNotes": "When conducting accessibility testing, testers may come across barriers that could be accessibility-related issues, or they could be unrelated. If you're unsure whether the problem you've identified is a genuine accessibility issue, the following steps can help you verify it.",
+          "generalNotes": "While testing for accessibility you may encounter barriers which could be related or unrelated to accessibility. If unsure, the following steps can help verify it.",
           "gherkin": null,
           "condensed": null,
           "criteria": null,


### PR DESCRIPTION
Reducing the subheading text found on the "How to: Not Sure if it is An Issue" page.

Please review:
- [ ]  Run the project using npm start
- [ ]  Cross compare the new subheading text with previous image of the text found on issue #300. 
- [ ]  Check that the same context of the subheading is clear for a summary for the page. 

This will resolve issue #300 