### PR TITLE
fix: jsx-a11y build error

### DIFF
--- a/src/components/accessible-demo/accessible-demo.tsx
+++ b/src/components/accessible-demo/accessible-demo.tsx
@@ -112,6 +112,7 @@ const AccessibleDemo: React.FC = () => {
                     Over 1/4 of the US population has a disability that requires assistive technology or accommodation.
                 </details>
 
+                {/* eslint-disable jsx-a11y/no-redundant-roles */}
                 <details>
                     <summary>How do we test our products?</summary>
                     <ol role="list">
@@ -124,6 +125,7 @@ const AccessibleDemo: React.FC = () => {
                         </li>
                     </ol>
                 </details>
+                 {/* eslint-enable jsx-a11y/no-redundant-roles */}
 
                 <details>
                     <summary>What screen reader should I use to test?</summary>


### PR DESCRIPTION
quick fix for build error, ignore 1 eslint rule for a few lines

build was breaking on warning about:

> warning  The element ol has an implicit role of list. Defining this explicitly is redundant and should be avoided      jsx-a11y/no-redundant-roles
and
> warning  The element li has an implicit role of listitem. Defining this explicitly is redundant and should be avoided  jsx-a11y/no-redundant-roles