### PR TITLE
Updated menu logo style switch fixes: #326

### DIFF
--- a/src/components/navigation/top-nav/top-nav.scss
+++ b/src/components/navigation/top-nav/top-nav.scss
@@ -64,7 +64,7 @@
       width: 297px;
       height: 40px;
 
-      @media (max-width: 960px) {
+      @media (max-width: 1025px) {
         background-image: url("../../../assets/svgs/Magenta11yLogoSm.svg");
         width: 176px;
         height: 59px;


### PR DESCRIPTION
Moved the change out from the 2 line logo to 1 line logo from 960 to 1025 to give the menu items more room