### PR TITLE
Issue 374: fix radios on forms pages

### DIFF
--- a/public/content/documentation/how-to-test/type/forms-&-inputs.md
+++ b/public/content/documentation/how-to-test/type/forms-&-inputs.md
@@ -42,17 +42,17 @@
    Radio buttons allow users to select a single option from a list. Only one radio button in a group should be be selectable at a time. Keyboard and screen reader users should be able to focus on the group of radio buttons using the tab key. Arrow keys move focus between each radio option. Options can be automatically selected as they receive focus with the arrow keys, or they can be selected using the space key. Pressing tab navigates aways from the radio group.
 
    <example>
-      <fieldset>
-        <legend>
-          Choose a fruit
-        </legend>
-        <input type="radio" name="fruit" id="appleRadio">
-        <label for="appleRadio">Apple</label>
-        <input type="radio" name="fruit" id="bananaRadio">
-        <label for="bananaRadio">Banana</label>
-        <input type="radio" name="fruit" id="cherryRadio" checked="">
-        <label for="cherryRadio">Cherry</label>
+    <form>
+      <fieldset className="fieldset">
+      <legend className="legend h-charlie">Choose a fruit</legend>
+        <input type="radio" name="fruit" id="appleRadio" className="radio">
+        <label for="appleRadio" className="label">Apple</label>
+        <input type="radio" name="fruit" id="bananaRadio" className="radio">
+        <label for="bananaRadio" className="label">Banana</label>
+        <input type="radio" name="fruit" id="cherryRadio" className="radio">
+        <label for="cherryRadio" className="label">Cherry</label>
       </fieldset>
+    </form>
    </example>
 
 4. **Select Fields**

--- a/public/content/documentation/web/page-level/form.md
+++ b/public/content/documentation/web/page-level/form.md
@@ -544,16 +544,16 @@ Use `fieldset` and `legend` to group related fields, such as:
 ```
 <example>
     <form aria-label="Contact us">
-          <fieldset>
-            <legend>
+          <fieldset className="fieldset">
+            <legend className="legend h-charlie">
               Preferred contact method
             </legend>
-            <input type="radio" name="method" id="contact-email" checked>
-            <label for="contact-email">Email</label>
-            <input type="radio" name="method" id="contact-sms">
-            <label for="contact-sms">SMS text</label>
-            <input type="radio" name="method" id="contact-phone">
-            <label for="contact-phone">Phone</label>
+            <input type="radio" name="method" id="contact-email" className="radio">
+            <label for="contact-email" className="label">Email</label>
+            <input type="radio" name="method" id="contact-sms" className="radio">
+            <label for="contact-sms" className="label">SMS text</label>
+            <input type="radio" name="method" id="contact-phone" className="radio">
+            <label for="contact-phone" className="label">Phone</label>
           </fieldset>
           <fieldset>
             <legend>


### PR DESCRIPTION
Fixed radio buttons not appearing on the following pages: 

- /web-criteria/page-level/form?tab=2 (bottom of page)
- /how-to-test-criteria/type/forms-&-inputs

They should look like the radio buttons on/ basic-accessible-webpage and work as expected with mouse and keyboard. 