### PR TITLE
Issue 281: fix video paths for native expandable and pagination (iOS) videos

### DIFF
--- a/public/content/documentation/native/controls/expandable.md
+++ b/public/content/documentation/native/controls/expandable.md
@@ -6,7 +6,7 @@ How to test an expandable region
 
 ### iOS Voiceover
 <video controls>
-  <source src="media/video/native/expandable/expandable-iOSVoiceOver.webm" type="video/webm">
+  <source src="media/video/native/expandable/expandable-iOSVoiceover.webm" type="video/webm">
   Your browser does not support the video tag.
 </video>
 

--- a/public/content/documentation/native/controls/pagination-control.md
+++ b/public/content/documentation/native/controls/pagination-control.md
@@ -7,7 +7,7 @@ How to test a pagination control
 ### iOS VoiceOver
 
 <video controls>
-  <source src="media/video/native/pagination-control/pagination-control_IosVoiceover.webm" type="video/webm">
+  <source src="media/video/native/pagination-control/pagination-control_IosVoiceOver.webm" type="video/webm">
   Your browser does not support the video tag.
 </video>
 


### PR DESCRIPTION
The file paths for native **expandable** and **pagination** (iOS) videos had a typo and so wasn't displaying. These should be fixed now.

