### PR TITLE
Issue 388: edit styles of code blocks for dark mode

### DIFF
--- a/src/styles/_code-blocks.scss
+++ b/src/styles/_code-blocks.scss
@@ -9,6 +9,14 @@ pre {
   color: var(--color-on-tertiary); /* Adapts to theme */
 }
 
+/* stylelint-disable no-duplicate-selectors */
+@media (prefers-color-scheme: dark) {
+  pre {
+    background-color: var(--color-on-primary); /* Dark mode background */
+    border: 1px solid var(--color-outline);
+  }
+}
+
 code {
   font-family: monospace;
   color: var(--color-text-secondary);
@@ -42,19 +50,22 @@ code {
 }
 
 /* Tag attributes (e.g., id, class) */
-.hljs-attr {
-  color: var(--color-info); /* Tertiary color for attributes */
+.hljs-attr,
+.hljs-title,
+.hljs-variable, {
+  color: var(--color-info);
 }
 
 /* Attribute values (e.g., "example-header") */
-.hljs-string {
-  color: var(--color-error-container); /* Light color for attribute values */
+.hljs-string,
+.hljs-literal {
+  color: var(--color-critical); /* Light color for attribute values */
   font-weight: normal;
 }
 
 /* Comments */
 .hljs-comment {
-  color: var(--color-success); /* Muted color for comments */
+  color: var(--color-caution); /* Muted color for comments */
 
 }
 
@@ -64,21 +75,21 @@ code {
 }
 
 /* Operators, such as `=` */
-.hljs-operator {
-  color: var(--color-error); /* Error color for operators */
-}
+//  {
+//   color: var(--color-error); /* Error color for operators */
+// }
 
 /* Keywords */
-.hljs-keyword {
-  /* Accent color for keywords */
+.hljs-keyword,
+.hljs-type {
   color: var(--color-on-primary-container); 
-  font-weight: bold;
 }
 
 /* HTML entity or URL */
 .hljs-entity,
-.hljs-url {
-  color: var(--color-link); /* Link color for entities and URLs */
+.hljs-url,
+.hljs-operator{
+  color: var(--color-primary); /* Link color for entities and URLs */
 }
 
 /* Functions and properties */
@@ -88,6 +99,7 @@ code {
 }
 
 /* Numbers */
-.hljs-number {
+.hljs-number,
+.hljs-meta {
   color: var(--color-info); /* Secondary color for numbers */
 }


### PR DESCRIPTION
Per [the issue logged](https://github.com/tmobile/magentaA11y/issues/388), there are various Native App criteria pages that have examples but the text within the `pre` and `code` blocks do show color differentiation in dark mode like it does in light mode. For instance, if a keyword is highlighted in light mode it may not be highlighted in dark mode. 

- I edited the styles to make sure all differentiation shown in light is shown, in some way, in dark mode as well. 
- Also, for dark mode only I edited the background color of the `pre` box and gave it a border. This was done to help provide more contrast while ensuring we still delineating a code block section from a regular text block section. 

Basically, **as a reviewer you need** to check code blocks in native criteria pages:
- so that there's sufficient color contrast on light and dark modes for text and backgrounds
- where a piece of code (i.e. an attribute or comment) has color differentiation in light mode, ensure it has some differentiation from regular text in dark mode

Note, they all use the same classes so you should only need to look at 2-3 native code examples to see the full range of styles. 