### PR TITLE
MGA11Y-48: Add css scoping to demo pages

### DIFF
--- a/src/components/accessible-demo/accessible-demo.scss
+++ b/src/components/accessible-demo/accessible-demo.scss
@@ -102,7 +102,7 @@
 
   /* stylelint-disable no-duplicate-selectors */
   @media (prefers-color-scheme: dark) {
-    .icon {
+    .demo-page .icon {
       filter: invert(100%) hue-rotate(180deg);
     }
   }

--- a/src/components/accessible-demo/accessible-demo.tsx
+++ b/src/components/accessible-demo/accessible-demo.tsx
@@ -49,7 +49,7 @@ const AccessibleDemo: React.FC = () => {
 
   return (
     <>
-    <div className="flex-col">
+    <div className="demo-page flex-col">
         <div className="hero">
             <section className="">
                 <div className="flex-row">

--- a/src/components/inaccessible-demo/inaccessible-demo.tsx
+++ b/src/components/inaccessible-demo/inaccessible-demo.tsx
@@ -50,7 +50,7 @@ const InaccessibleDemo: React.FC = () => {
 
   return (
     <>
-    <div className="flex-col">
+    <div className="demo-page flex-col">
         <div className="hero">
             <div className="">
                 <div className="flex-row">


### PR DESCRIPTION
Addresses bug with missing icons in Dark Mode due to CSS specificity / cascade issues related to the inaccessible/accessible demo pages. 

1. Added more specific class names for demo page
2. Updates styles

Fixes #403