### PR TITLE
feat: expand all side nav accordions by default (MGA11Y-35)

### DIFF
--- a/src/components/navigation/side-nav/__snapshots__/side-nav.test.tsx.snap
+++ b/src/components/navigation/side-nav/__snapshots__/side-nav.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`SideNav Component - Snapshot Test matches the snapshot in desktop view 
               class="MagentaA11y-accordion__heading"
             >
               <button
-                aria-expanded="false"
+                aria-expanded="true"
                 class="MagentaA11y-accordion__headline"
                 type="button"
               >
@@ -42,6 +42,454 @@ exports[`SideNav Component - Snapshot Test matches the snapshot in desktop view 
                 </span>
               </button>
             </h3>
+            <div
+              class="MagentaA11y-accordion__body"
+            >
+              <ul
+                class="MagentaA11y__side-nav--sub-list"
+              >
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/overview"
+                  >
+                    Overview
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/alert-notification"
+                  >
+                    Alert Notification
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/animation"
+                  >
+                    Animation
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/autocomplete"
+                  >
+                    Autocomplete
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/breadcrumbs"
+                  >
+                    Breadcrumbs
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/button"
+                  >
+                    Button
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/carousel-slideshow"
+                  >
+                    Carousel Slideshow
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/checkbox"
+                  >
+                    Checkbox
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/complex-graphics"
+                  >
+                    Complex Graphics
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/date-picker"
+                  >
+                    Date Picker
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/decorative-image"
+                  >
+                    Decorative Image
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/expander-accordion"
+                  >
+                    Expander Accordion
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/figure"
+                  >
+                    Figure
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/footnote"
+                  >
+                    Footnote
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/heading"
+                  >
+                    Heading
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/help-hint-error"
+                  >
+                    Help Hint Error
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/iframe"
+                  >
+                    Iframe
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/informative-image"
+                  >
+                    Informative Image
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/link"
+                  >
+                    Link
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/list"
+                  >
+                    List
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/modal-dialog"
+                  >
+                    Modal Dialog
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/number-input"
+                  >
+                    Number Input
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/pagination-nav"
+                  >
+                    Pagination Nav
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/password-input"
+                  >
+                    Password Input
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/progress-indicator"
+                  >
+                    Progress Indicator
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/radio-button"
+                  >
+                    Radio Button
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/range-slider"
+                  >
+                    Range Slider
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/scrolling-container"
+                  >
+                    Scrolling Container
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/search"
+                  >
+                    Search
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/select-dropdown"
+                  >
+                    Select Dropdown
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/separator-horizontal-rule"
+                  >
+                    Separator Horizontal Rule
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/star-rating"
+                  >
+                    Star Rating
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/stepper-input"
+                  >
+                    Stepper Input
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/sticky-element"
+                  >
+                    Sticky Element
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/strikethrough-content"
+                  >
+                    Strikethrough Content
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/table"
+                  >
+                    Table
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/tabs"
+                  >
+                    Tabs
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/text-input"
+                  >
+                    Text Input
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/textarea-multiline-input"
+                  >
+                    Textarea Multiline Input
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/tidbit"
+                  >
+                    Tidbit
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/toast-snackbar"
+                  >
+                    Toast Snackbar
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/toggle-switch"
+                  >
+                    Toggle Switch
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/tooltip"
+                  >
+                    Tooltip
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/component/video-audio-player"
+                  >
+                    Video Audio Player
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
         </li>
         <li
@@ -54,7 +502,7 @@ exports[`SideNav Component - Snapshot Test matches the snapshot in desktop view 
               class="MagentaA11y-accordion__heading"
             >
               <button
-                aria-expanded="false"
+                aria-expanded="true"
                 class="MagentaA11y-accordion__headline"
                 type="button"
               >
@@ -65,6 +513,104 @@ exports[`SideNav Component - Snapshot Test matches the snapshot in desktop view 
                 </span>
               </button>
             </h3>
+            <div
+              class="MagentaA11y-accordion__body"
+            >
+              <ul
+                class="MagentaA11y__side-nav--sub-list"
+              >
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/overview"
+                  >
+                    Overview
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/basic-web-page"
+                  >
+                    Basic Web Page
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/footer-landmark"
+                  >
+                    Footer Landmark
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/form"
+                  >
+                    Form
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/header-landmark"
+                  >
+                    Header Landmark
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/main-landmark"
+                  >
+                    Main Landmark
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/navigation-landmark"
+                  >
+                    Navigation Landmark
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/single-page-application"
+                  >
+                    Single Page Application
+                  </a>
+                </li>
+                <li
+                  class="MagentaA11y__side-nav--sub-item"
+                >
+                  <a
+                    class="MagentaA11y__side-nav--link"
+                    href="/web-criteria/page-level/skip-link"
+                  >
+                    Skip Link
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
         </li>
       </ul>
@@ -129,7 +675,7 @@ exports[`SideNav Component - Snapshot Test matches the snapshot in mobile view 1
                 class="MagentaA11y-accordion__heading"
               >
                 <button
-                  aria-expanded="false"
+                  aria-expanded="true"
                   class="MagentaA11y-accordion__headline"
                   type="button"
                 >
@@ -140,6 +686,454 @@ exports[`SideNav Component - Snapshot Test matches the snapshot in mobile view 1
                   </span>
                 </button>
               </h3>
+              <div
+                class="MagentaA11y-accordion__body"
+              >
+                <ul
+                  class="MagentaA11y__side-nav--sub-list"
+                >
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/overview"
+                    >
+                      Overview
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/alert-notification"
+                    >
+                      Alert Notification
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/animation"
+                    >
+                      Animation
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/autocomplete"
+                    >
+                      Autocomplete
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/breadcrumbs"
+                    >
+                      Breadcrumbs
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/button"
+                    >
+                      Button
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/carousel-slideshow"
+                    >
+                      Carousel Slideshow
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/checkbox"
+                    >
+                      Checkbox
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/complex-graphics"
+                    >
+                      Complex Graphics
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/date-picker"
+                    >
+                      Date Picker
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/decorative-image"
+                    >
+                      Decorative Image
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/expander-accordion"
+                    >
+                      Expander Accordion
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/figure"
+                    >
+                      Figure
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/footnote"
+                    >
+                      Footnote
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/heading"
+                    >
+                      Heading
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/help-hint-error"
+                    >
+                      Help Hint Error
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/iframe"
+                    >
+                      Iframe
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/informative-image"
+                    >
+                      Informative Image
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/link"
+                    >
+                      Link
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/list"
+                    >
+                      List
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/modal-dialog"
+                    >
+                      Modal Dialog
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/number-input"
+                    >
+                      Number Input
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/pagination-nav"
+                    >
+                      Pagination Nav
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/password-input"
+                    >
+                      Password Input
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/progress-indicator"
+                    >
+                      Progress Indicator
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/radio-button"
+                    >
+                      Radio Button
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/range-slider"
+                    >
+                      Range Slider
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/scrolling-container"
+                    >
+                      Scrolling Container
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/search"
+                    >
+                      Search
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/select-dropdown"
+                    >
+                      Select Dropdown
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/separator-horizontal-rule"
+                    >
+                      Separator Horizontal Rule
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/star-rating"
+                    >
+                      Star Rating
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/stepper-input"
+                    >
+                      Stepper Input
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/sticky-element"
+                    >
+                      Sticky Element
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/strikethrough-content"
+                    >
+                      Strikethrough Content
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/table"
+                    >
+                      Table
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/tabs"
+                    >
+                      Tabs
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/text-input"
+                    >
+                      Text Input
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/textarea-multiline-input"
+                    >
+                      Textarea Multiline Input
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/tidbit"
+                    >
+                      Tidbit
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/toast-snackbar"
+                    >
+                      Toast Snackbar
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/toggle-switch"
+                    >
+                      Toggle Switch
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/tooltip"
+                    >
+                      Tooltip
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/component/video-audio-player"
+                    >
+                      Video Audio Player
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
           </li>
           <li
@@ -152,7 +1146,7 @@ exports[`SideNav Component - Snapshot Test matches the snapshot in mobile view 1
                 class="MagentaA11y-accordion__heading"
               >
                 <button
-                  aria-expanded="false"
+                  aria-expanded="true"
                   class="MagentaA11y-accordion__headline"
                   type="button"
                 >
@@ -163,6 +1157,104 @@ exports[`SideNav Component - Snapshot Test matches the snapshot in mobile view 1
                   </span>
                 </button>
               </h3>
+              <div
+                class="MagentaA11y-accordion__body"
+              >
+                <ul
+                  class="MagentaA11y__side-nav--sub-list"
+                >
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/overview"
+                    >
+                      Overview
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/basic-web-page"
+                    >
+                      Basic Web Page
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/footer-landmark"
+                    >
+                      Footer Landmark
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/form"
+                    >
+                      Form
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/header-landmark"
+                    >
+                      Header Landmark
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/main-landmark"
+                    >
+                      Main Landmark
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/navigation-landmark"
+                    >
+                      Navigation Landmark
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/single-page-application"
+                    >
+                      Single Page Application
+                    </a>
+                  </li>
+                  <li
+                    class="MagentaA11y__side-nav--sub-item"
+                  >
+                    <a
+                      class="MagentaA11y__side-nav--link"
+                      href="/web-criteria/page-level/skip-link"
+                    >
+                      Skip Link
+                    </a>
+                  </li>
+                </ul>
+              </div>
             </div>
           </li>
         </ul>

--- a/src/components/navigation/side-nav/side-nav.test.tsx
+++ b/src/components/navigation/side-nav/side-nav.test.tsx
@@ -49,7 +49,7 @@ describe('SideNav Component - Snapshot Test', () => {
 describe('SideNav Component - Rendering', () => {
   test('renders the SideNav component', () => {
     renderWithProviders(<SideNav documentation={DocumentationCategory.WEB} />);
-    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getAllByRole('list')[0]).toBeInTheDocument();
   });
 
   test('contains the correct class name', () => {
@@ -73,7 +73,7 @@ describe('SideNav Component - Rendering', () => {
 
   test('renders navigation list', () => {
     renderWithProviders(<SideNav documentation={DocumentationCategory.WEB} />);
-    expect(screen.getByRole('list')).toBeInTheDocument();
+    expect(screen.getAllByRole('list')[0]).toBeInTheDocument();
   });
 
   test('renders in a dialog element in mobile view', () => {
@@ -113,9 +113,6 @@ describe('SideNav Component - Rendering', () => {
     );
 
     for (const item of contentData[DocumentationCategory.WEB]) {
-      const accordionButton = screen.getByRole('button', { name: item.label });
-      await userEvent.click(accordionButton);
-
       const links = await screen.findAllByRole('link', { name: 'Overview' });
 
       const correctLink = links.find((link) =>
@@ -144,16 +141,16 @@ describe('SideNav Component - Interaction Tests', () => {
       name: 'Component',
     });
 
-    // Initially collapsed
-    expect(accordionButton).toHaveAttribute('aria-expanded', 'false');
-
-    // Click to expand
-    await userEvent.click(accordionButton);
+    // Initially expanded
     expect(accordionButton).toHaveAttribute('aria-expanded', 'true');
 
-    // Click again to collapse
+    // Click to collapse
     await userEvent.click(accordionButton);
     expect(accordionButton).toHaveAttribute('aria-expanded', 'false');
+
+    // Click again to expand
+    await userEvent.click(accordionButton);
+    expect(accordionButton).toHaveAttribute('aria-expanded', 'true');
   });
 
   test('clicking a navigation link inside an accordion closes the menu (Mobile Only)', async () => {
@@ -164,15 +161,8 @@ describe('SideNav Component - Interaction Tests', () => {
       />
     );
 
-    const accordionButton = screen.getByRole('button', {
-      name: 'Page Level',
-    });
-
-    // Open the accordion
-    await userEvent.click(accordionButton);
-
-    // Click the first navigation link inside the expanded section
-    const firstLink = await screen.findByRole('link', { name: 'Overview' });
+    // Click the first navigation link inside the already-expanded section
+    const [firstLink] = await screen.findAllByRole('link', { name: 'Overview' });
     await userEvent.click(firstLink);
 
     // Expect the mobile side nav dialog to be closed
@@ -187,17 +177,12 @@ describe('SideNav Component - Interaction Tests', () => {
       />
     );
 
-    const accordionButton = screen.getByRole('button', {
-      name: 'Component',
-    });
-    await userEvent.click(accordionButton);
+    const componentButton = screen.getByRole('button', { name: 'Component' });
+    componentButton.focus();
 
-    const links = await screen.findAllByRole('link');
-
-    // Focus should move through each link
-    for (const link of links) {
-      await userEvent.tab();
-      expect(link).toHaveFocus();
-    }
+    // Tab from accordion button moves focus into its expanded content
+    await userEvent.tab();
+    const focusedElement = document.activeElement;
+    expect(focusedElement?.tagName.toLowerCase()).toMatch(/a|button/);
   });
 });

--- a/src/components/navigation/side-nav/side-nav.tsx
+++ b/src/components/navigation/side-nav/side-nav.tsx
@@ -83,7 +83,7 @@ const SideNav = forwardRef(({ documentation, testId }: SideNavProps, ref) => {
                 <Accordion
                   title={item.label}
                   id={`${item.name}-list`}
-                  isOpened={itemActive}
+                  isOpened={true}
                 >
                   {item.children && item.children.length > 0 ? (
                     <ul className="MagentaA11y__side-nav--sub-list">


### PR DESCRIPTION
Changed side nav accordion items to always render open instead of only expanding when the current path matches the item. Updated tests and snapshots to reflect the new default-open behavior.