### PR TITLE
Remove animated material focus ring

### DIFF
--- a/src/components/content-display/content-display.scss
+++ b/src/components/content-display/content-display.scss
@@ -54,6 +54,12 @@
       width: var(--tab-width);
     }
 
+    // Remove Material's custom animated magenta focus ring on tabs;
+    // rely on the default browser focus ring instead (see src/index.scss).
+    md-primary-tab::part(focus-ring) {
+      display: none;
+    }
+
     &__buttons {
       display: flex;
       gap: var(--magentaa11y-spacing-size-24);

--- a/src/components/my-criteria/my-criteria.scss
+++ b/src/components/my-criteria/my-criteria.scss
@@ -38,6 +38,12 @@
     md-tabs {
       width: fit-content;
     }
+
+    // Remove Material's custom animated magenta focus ring on tabs;
+    // rely on the default browser focus ring instead (see src/index.scss).
+    md-primary-tab::part(focus-ring) {
+      display: none;
+    }
   }
 
   &__tab-container {


### PR DESCRIPTION
Removes the custom animated Material focus ring from Tabs. FIxes #336

```
md-primary-tab::part(focus-ring) {
      display: none;
    }
```