### PR TITLE
Fix closing tag on button example

### DIFF
--- a/public/content/documentation/web/component/button.md
+++ b/public/content/documentation/web/component/button.md
@@ -190,10 +190,10 @@ Sometimes the design will call for multiple buttons with the same text label. In
 ```html
 <button aria-label="Edit payment date">
   Edit
-</div>
+</button>
 <button aria-label="Edit payment amount">
   Edit
-</div>
+</button>
 ```
 
 ## Developer notes


### PR DESCRIPTION
Fixes #425 - Closing tag cleanup on one button example in dev docs for Web -> Button